### PR TITLE
Normalize password rules and hashing

### DIFF
--- a/app/Livewire/User/Profile.php
+++ b/app/Livewire/User/Profile.php
@@ -6,6 +6,8 @@ use App\Livewire\Traits\Alert;
 use App\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules;
 use Livewire\Component;
 
 class Profile extends Component
@@ -34,8 +36,8 @@ class Profile extends Component
             'password' => [
                 'nullable',
                 'string',
-                'min:8',
-                'confirmed'
+                'confirmed',
+                Rules\Password::defaults()
             ]
         ];
     }
@@ -49,7 +51,7 @@ class Profile extends Component
     {
         $this->validate();
 
-        $this->user->password = when($this->password !== null, bcrypt($this->password), $this->user->password);
+        $this->user->password = when($this->password !== null, Hash::make($this->password), $this->user->password);
         $this->user->update();
 
         $this->dispatch('updated', name: $this->user->name);


### PR DESCRIPTION
Normalized the password rules in profile to use Laravel's defaults, which makes [defining default password rules](https://laravel.com/docs/12.x/validation#defining-default-password-rules) easier and updated the hashing method from `bcrypt` to Laravel's `Hash::make` to match how the password is originally hashed, which also makes it easier to change algorithms later.

The default is `min:8` so it could be removed from the rules.