### PR TITLE
Removing `rules generator` from the Form `password` Component

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -15,7 +15,7 @@
         </div>
 
         <div class="mt-4">
-            <x-password label="Password *" name="password" required autocomplete="new-password" rules generator />
+            <x-password label="Password *" name="password" required autocomplete="new-password" />
         </div>
 
         <div class="mt-4">


### PR DESCRIPTION
Relates to #3 